### PR TITLE
Gives mindshield implants to hotel security staff

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -331,6 +331,7 @@
 	head = /obj/item/clothing/head/helmet/blueshirt
 	back = /obj/item/storage/backpack/security
 	belt = /obj/item/storage/belt/security/full
+	implants = list(/obj/item/implant/mindshield)
 
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))


### PR DESCRIPTION
for the shotgun

[Changelogs]: # adds mindshield implants to securirty

:cl: optional name here
tweak: hotel security staff are now mindshielded
/:cl:

[why]: # this allow them to use the energy shotgun they get, wich is their only weapon
