### PR TITLE
Sets devil and devil agentrs as continous game mode

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -118,6 +118,8 @@ CONTINUOUS WIZARD
 CONTINUOUS BLOB
 CONTINUOUS ABDUCTION
 #CONTINUOUS MONKEY
+CONTINUOUS DEVIL
+CONTINUOUS DEVIL_AGENTS
 
 ##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
 


### PR DESCRIPTION
[Changelogs]: # Devils no longer ends at antag death

fix: Devils will no longer end at antag ends, and other rounds will not end when no devils are selected at mid round antag
[why]: # One of the major reason devil sucks is the way they suddenly end, unlike wizardss, they are not capable of taking the whole station on themselve, nor have anyway to prepare correctly before they can be killed, and also, round ends if the devil dies even when it can revive later on. also when this game mode gets selected after other antag dies, it ends the round inmidiatly, including tator rounds